### PR TITLE
Support OpenAPI specification with `consumes` property `undefined`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -355,6 +355,11 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+    },
     "async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
@@ -1521,6 +1526,16 @@
       "requires": {
         "slice-ansi": "^1.0.0",
         "string-width": "^2.0.0"
+      },
+      "dependencies": {
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        }
       }
     },
     "cli-width": {
@@ -6708,9 +6723,9 @@
       "dev": true
     },
     "progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
     "pseudomap": {
@@ -7423,10 +7438,12 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
+      "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
       "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
@@ -7858,6 +7875,17 @@
         "lodash": "^4.17.10",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        }
       }
     },
     "term-size": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3899,7 +3899,7 @@
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
@@ -4827,7 +4827,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
@@ -6708,9 +6708,9 @@
       "dev": true
     },
     "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
       "dev": true
     },
     "pseudomap": {

--- a/src/core/spec/start/normalize/content_negotiation.js
+++ b/src/core/spec/start/normalize/content_negotiation.js
@@ -13,6 +13,11 @@ const getNegotiationsParams = function({ spec, operation, params }) {
 // A random request Content-Type will be picked
 const getContentTypeParam = function({ spec, operation, params }) {
   const consumes = getConsumes({ spec, operation })
+
+  if(consumes === undefined) {
+    return
+  }
+
   const consumesA = filterFormDataMimes({ mimes: consumes, params })
 
   if (consumesA === undefined) {

--- a/src/core/spec/start/normalize/content_negotiation.js
+++ b/src/core/spec/start/normalize/content_negotiation.js
@@ -20,10 +20,6 @@ const getContentTypeParam = function({ spec, operation, params }) {
 
   const consumesA = filterFormDataMimes({ mimes: consumes, params })
 
-  if (consumesA === undefined) {
-    return
-  }
-
   const value = { type: 'string', enum: consumesA }
   return { 'headers.content-type': value }
 }

--- a/src/core/spec/start/normalize/content_negotiation.js
+++ b/src/core/spec/start/normalize/content_negotiation.js
@@ -14,12 +14,11 @@ const getNegotiationsParams = function({ spec, operation, params }) {
 const getContentTypeParam = function({ spec, operation, params }) {
   const consumes = getConsumes({ spec, operation })
 
-  if(consumes === undefined) {
+  if (consumes === undefined) {
     return
   }
 
   const consumesA = filterFormDataMimes({ mimes: consumes, params })
-
   const value = { type: 'string', enum: consumesA }
   return { 'headers.content-type': value }
 }


### PR DESCRIPTION
I found that when the content type is not defined - I'm hitting the following:

This resolved the issue for me.

```
OS: darwin
node.js: v10.11.0
test-openapi: 38.1.1

TypeError: Cannot read property 'filter' of undefined
    at removeFormDataMimes (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/form_data.js:32:24)
    at filterFormDataMimes (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/form_data.js:11:10)
    at getContentTypeParam (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/content_negotiation.js:21:21)
    at getNegotiationsParams (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/content_negotiation.js:7:23)
    at getParams (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/params/main.js:24:31)
    at getOperation (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/main.js:34:18)
    at Object.entries.map (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/main.js:27:5)
    at Array.map (<anonymous>)
    at getOperationsByPath (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/main.js:26:35)
    at Object.entries.map (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/main.js:16:5)
```