### PR TITLE
OpenAPI 3.0 support for basic bearer auth security type

### DIFF
--- a/src/core/spec/start/normalize/params/security.js
+++ b/src/core/spec/start/normalize/params/security.js
@@ -10,15 +10,38 @@ const IN_TO_LOCATION = require('./in_to_location')
 // Normalize OpenAPI security request parameters into specification-agnostic
 // format
 const getSecParams = function({
-  spec: { securityDefinitions, security: apiSecurity = [] },
+  spec: {
+    securityDefinitions,
+    security: apiSecurity = [],
+    components: {
+      securitySchemes: secSchemes
+    }
+  },
   operation: { security = apiSecurity },
 }) {
   const secRefs = getSecRefs({ security })
+  const secDef = getSecDefs({ securityDefinitions, securitySchemes: secSchemes})
   const secParams = secRefs.map(([secName, scopes]) =>
-    getSecParam({ secName, scopes, securityDefinitions }),
+    getSecParam({ secName, scopes, securityDefinitions: secDef }),
   )
   const secParamsA = Object.assign({}, ...secParams)
   return secParamsA
+}
+
+const getSecDefs = function({ securityDefinitions, securitySchemes }) {
+  // Check if either 2.0 or 3.0 exist
+  if ((securityDefinitions === undefined) && (securitySchemes === undefined)) {
+    throw new TestOpenApiError(
+      `Could not find OpenAPI 2 'securityDefinitions' or OpenAPI 3 'components.securitySchemes' from the spec root`
+    )
+  }
+
+  // Check for 2.0
+  if (securityDefinitions === undefined) {
+    return securitySchemes
+  }
+
+  return securityDefinitions
 }
 
 const getSecRefs = function({ security }) {
@@ -62,9 +85,30 @@ const getDefApiKey = function({ name, in: paramIn }) {
   return { [key]: { type: 'string', optional: true } }
 }
 
+const getDefHttpKey = function({ scheme }) {
+  const scheme_type = HTTP_SCHEME_TYPES[scheme]
+
+  if (scheme_type === undefined) {
+    throw new TestOpenApiError(
+      `Other HTTP schemes defined by RFC 7235 not yet supported`,
+    )
+  }
+
+  const location = IN_TO_LOCATION['headers']
+  const key = locationToKey({ name: 'Authorization', location})
+
+  return { [key]: { type: 'string', optional: false } }
+}
+
 const SECURITY_DEFS = {
   apiKey: getDefApiKey,
+  http: getDefHttpKey
 }
+
+const HTTP_SCHEME_TYPES = Object.freeze({
+  "basic": 1,
+  "bearer": 2
+})
 
 module.exports = {
   getSecParams,


### PR DESCRIPTION
When attempting to use the `components.securitySchemes` definition in OAPI 3.0 I get the following error.  This stubs in basic support and is probably a starting point for 2.0 support (not tested)?

This allows a task to define an auth header as such:

authHeader.tasks.yml
```
- name: authExampleTest
  spec:
    ...
  call:
    ...
    headers.authorization: 'Bearer TOKEN'
  validate:
    ...
```


openapi.yml 3.0 example
```
security:
  - bearerAuth: []

...

components:
  securitySchemes:
    bearerAuth:
      type: http
      scheme: bearer

```

```
⢀⠀ 0/1A bug occurred.
Please report an issue on the 'test-openapi-plugin-spec' code repository and paste the following lines:

OS: darwin
node.js: v10.11.0
test-openapi: 38.1.1

TypeError: Cannot read property 'bearerAuth' of undefined
    at getSecParam (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/params/security.js:33:42)
    at secRefs.map (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/params/security.js:18:5)
    at Array.map (<anonymous>)
    at getSecParams (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/params/security.js:17:29)
    at getParams (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/params/main.js:32:21)
    at getOperation (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/main.js:34:18)
    at Object.entries.map (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/main.js:27:5)
    at Array.map (<anonymous>)
    at getOperationsByPath (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/main.js:26:35)
    at Object.entries.map (/Users/jpettit/dev/github/test-openapi/src/core/spec/start/normalize/main.js:16:5)
```