### PR TITLE
Enable ajv version 6 with json schema draft-06 support

### DIFF
--- a/src/validation/meta.js
+++ b/src/validation/meta.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // eslint-disable-next-line import/no-internal-modules
-const JSON_SCHEMA_SCHEMA = require('ajv/lib/refs/json-schema-draft-04')
+const JSON_SCHEMA_SCHEMA = require('ajv/lib/refs/json-schema-draft-06')
 const { omit } = require('lodash')
 
 const { checkSchema } = require('./check')


### PR DESCRIPTION
Specifying a `const` value is only supported in json-schema 6.  Updating the schema draft enables validation of the following response body like so in a task:

```
# example json data: 
# { "field": "foobar" }

# task yml
...
  validate:
    status: 200
    body:
      properties:
        field:
          const: "foobar"
```